### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/kevinpierman-creator/WorkshopDiagnosticApp/security/code-scanning/5](https://github.com/kevinpierman-creator/WorkshopDiagnosticApp/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this `build` job, which only checks out code and runs a Gradle build, read-only access to repository contents is sufficient.

The best change, without altering existing behavior, is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`), so it applies to all jobs that don’t override it. We can use the standard minimal configuration:

```yaml
permissions:
  contents: read
```

This ensures the token can read repository contents for `actions/checkout`, but cannot write to contents, issues, pull requests, etc. Concretely, in `.github/workflows/build.yml`, insert the `permissions` block after the `name: Build` line and before the `on:` block. No imports, methods, or other definitions are needed since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
