### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build APKs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       # 1️⃣ Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/kevinpierman-creator/WorkshopDiagnosticApp/security/code-scanning/3](https://github.com/kevinpierman-creator/WorkshopDiagnosticApp/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions:` block for the workflow or for the specific job, restricting `GITHUB_TOKEN` to the least privileges necessary—in this case, read-only access to repository contents should be sufficient.

The best way to fix this specific workflow without changing functionality is to add a `permissions:` block at the job level under `jobs.build`, since the CodeQL warning is tied to that job. The job only needs to check out code and upload artifacts, so `contents: read` is adequate. No steps in the snippet write to the repo or interact with issues/PRs. Concretely, in `.github/workflows/android-build.yml`, under `jobs:`, inside the `build:` job, insert:

```yaml
    permissions:
      contents: read
```

indented to align with `name:` and `runs-on:` under `build:`. No imports or additional methods are needed; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
